### PR TITLE
Disable '-F' in lftp cls to avoid `@` decorators

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -6,7 +6,7 @@ parse_source_config() {
 
 get_listing() {
   GLOB=$(echo "$REGEXP" | sed 's/(.*)/*/')
-  LISTING=$(lftp -c "open $URL; cls -1 $GLOB")
+  LISTING=$(lftp -c "open $URL; set cmd:cls-default ''; cls -1 $GLOB")
 }
 
 parse_versions() {


### PR DESCRIPTION
When accessing pages on https://download.opensuse.org, I'm seeing a trailing `@` on the version. It looks like lftp is adding decorators to the file names. The default seems to add this, so I'm wondering if the defaults changed recently to break this? Or could it be the layout of the page changed?

From an intercepted container:
```
bash-4.3# lftp -c "set -a" | grep cls
set cmd:cls-completion-default -FBa
set cmd:cls-default -F
set cmd:cls-exact-time yes
```