### PR TITLE
Fixes to add ssh to docker container and make in and out work better (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse:42.2
 
-RUN zypper -n in jq lftp
+RUN zypper -n in jq lftp openssh
 
 ADD assets/ /opt/resource/
 RUN chmod +x /opt/resource/{check,in,out}

--- a/assets/check
+++ b/assets/check
@@ -17,9 +17,6 @@ exec 1>&2 # redirect all output to stderr for logging
 
 source $(dirname $0)/common.sh
 
-payload=$(mktemp /tmp/resource-in.XXXXXX)
-cat > $payload <&0
-
 parse_source_config
 
 output_single_version() {
@@ -38,8 +35,9 @@ output_current() {
 output_newer_versions() {
   VERSION="$1"
   REFS=''
+  REVERSE_VERSIONS=$(echo $FOUND_VERSIONS | sort -rh)
   local IFS=$'\n'
-  for version in $FOUND_VERSIONS; do
+  for version in $REVERSE_VERSIONS; do
     NEW_REF="{ \"ref\": \"$version\" }"
     if [ "${#REFS}" != "0" ]; then
       NEW_REF="{ \"ref\": \"$version\" },"

--- a/assets/check
+++ b/assets/check
@@ -17,6 +17,9 @@ exec 1>&2 # redirect all output to stderr for logging
 
 source $(dirname $0)/common.sh
 
+payload=$(mktemp /tmp/resource-in.XXXXXX)
+cat > $payload <&0
+
 parse_source_config
 
 output_single_version() {

--- a/assets/in
+++ b/assets/in
@@ -33,7 +33,8 @@ if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
 fi
 
 FILE=$(echo "$REGEXP" | sed -e "s/(.*)/$VERSION/")
-lftpget -c "$URL/$FILE"
+#lftpget -c "$URL/$FILE"
+lftp -c "open $URL; get $FILE"
 
 # The script must emit the fetched version, and may emit metadata as a list of key-value pairs. This data is intended for public consumption and will make it upstream, intended to be shown on the build's page.
 cat >&3 <<EOF

--- a/assets/out
+++ b/assets/out
@@ -12,6 +12,7 @@
 # }
 
 set -e
+IFS=" "
 
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging

--- a/assets/out
+++ b/assets/out
@@ -36,7 +36,8 @@ cd $source
 lftp -c "open $URL; mput $files"
 
 # The script must emit the resulting version of the resource.
-LISTING=$(ls -1 $files)
+#LISTING=$(ls -1 $files)
+get_listing
 parse_versions
 VERSION=$(echo $FOUND_VERSIONS | sort -rh | head -1)
 cat >&3 <<EOF


### PR DESCRIPTION
Added openssh to docker container.
Changed in to use lftp instead of lftpget so the URL could contain more parameters parsed by lftp.
Fixed out to fetch the listing from the remote.
Fixed check to actually output newer versions.