### PR TITLE
Auto accept host key to allow using SFTP

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -6,7 +6,7 @@ parse_source_config() {
 
 get_listing() {
   GLOB=$(echo "$REGEXP" | sed 's/(.*)/*/')
-  LISTING=$(lftp -c "open $URL; set cmd:cls-default ''; cls -1 $GLOB")
+  LISTING=$(lftp -c "set sftp:auto-confirm yes; set cmd:cls-default ''; open $URL; cls -1 $GLOB")
 }
 
 parse_versions() {

--- a/assets/in
+++ b/assets/in
@@ -33,7 +33,7 @@ if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
 fi
 
 FILE=$(echo "$REGEXP" | sed -e "s/(.*)/$VERSION/")
-lftp -c "open $URL; get $FILE"
+lftp -c "set sftp:auto-confirm yes; open $URL; get $FILE"
 
 # The script must emit the fetched version, and may emit metadata as a list of key-value pairs. This data is intended for public consumption and will make it upstream, intended to be shown on the build's page.
 cat >&3 <<EOF

--- a/assets/out
+++ b/assets/out
@@ -34,7 +34,7 @@ fi
 files=$(jq -r '.params.files // "*"' < $payload)
 
 cd $source
-lftp -c "open $URL; mput $files"
+lftp -c "set sftp:auto-confirm yes; open $URL; mput $files"
 
 # The script must emit the resulting version of the resource.
 get_listing


### PR DESCRIPTION
Using SFTP, there is no chance to let the resource know about the host key before establishing a connection. This PR allows to use SFTP by disabling host key verification.